### PR TITLE
add web-override config option, clean up useless code

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -34,5 +34,9 @@ options:
     default: ""
     description: |
       Secret key for session signing
- 
- 
+  web-override:
+    type: string
+    default: ""
+    description: |
+      systemd service override for snap.sentry.web.service.
+      Can be used to configure an http proxy.

--- a/src/reactive/sentry.py
+++ b/src/reactive/sentry.py
@@ -26,6 +26,7 @@ from charmhelpers.core.host import service_stop
 from charms.layer.sentry import (
     gen_random_string,
     render_sentry_config,
+    render_web_override,
     start_restart,
     SENTRY_BIN,
     SENTRY_WEB_SERVICE,
@@ -256,8 +257,16 @@ def block_on_no_redis():
     return
 
 
+@when('config.changed.web-override')
+def update_web_override():
+    render_web_override()
+    call(['systemctl', 'daemon-reload'])
+    start_restart(SENTRY_WEB_SERVICE)
+
+
 @hook('upgrade-charm')
 def migrate_sentry_db_on_upgrade():
     status_set('maintenance', 'Migrating Sentry DB')
     call('{} upgrade --noinput'.format(SENTRY_BIN).split())
     status_set('active', 'Sentry DB migration complete')
+

--- a/src/templates/web.override.conf.j2
+++ b/src/templates/web.override.conf.j2
@@ -1,0 +1,2 @@
+# This file is managed by juju
+{{environment}}


### PR DESCRIPTION
web-override notably allows the use a proxy for third-party
integrations (e.g. github).